### PR TITLE
Fetch sampling rules from AWS console

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .idea/
 vendor/
+composer.lock
+
+# Eclipse
+.settings/
+.buildpath
+.project

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,10 @@
 
     "require": {
         "php": ">=7.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "aws/aws-sdk-php": "^3.101",
+        "psr/http-message": "^1.0",
+        "psr/simple-cache": "^1.0"
     },
 
     "autoload": {

--- a/src/RequestMatcher.php
+++ b/src/RequestMatcher.php
@@ -1,0 +1,49 @@
+<?php
+namespace Pkerrigan\Xray;
+
+use Psr\Http\Message\ServerRequestInterface;
+
+class RequestMatcher
+{
+
+    public function matches(
+        ServerRequestInterface $request,
+        array $samplingRules): ?array
+    {
+        if (! uasort($samplingRules, function (
+            $samplingRule,
+            $otherSamplingRule) {
+            return $samplingRule["Priority"] - $otherSamplingRule["Priority"];
+        })) {
+            return null;
+        }
+
+        foreach ($samplingRules as $samplingRule) {
+            if ($this->match($request, $samplingRule)) {
+                return $samplingRule;
+            }
+        }
+
+        return null;
+    }
+
+    public function match(
+        ServerRequestInterface $request,
+        array $samplingRule): bool
+    {
+        if (! strcasecmp($request->getMethod(), $samplingRule["HTTPMethod"])) {
+            return false;
+        }
+
+        if (! preg_match("/{$samplingRule["URLPath"]}/", $request->getUri()->getPath())) {
+            return false;
+        }
+
+        if (! preg_match("/{$samplingRule["Host"]}/", $request->getUri()->getHost())) {
+            return false;
+        }
+
+        return true;
+    }
+}
+

--- a/src/SamplingRule/AwsSdkSamplingRule.php
+++ b/src/SamplingRule/AwsSdkSamplingRule.php
@@ -1,0 +1,30 @@
+<?php
+namespace Pkerrigan\Xray\SamplingRule;
+
+use Aws\XRay\XRayClient;
+
+class AwsSdkSamplingRule implements SamplingRule
+{
+
+    /** @var XRayClient */
+    private $xrayClient;
+
+    public function __construct(
+        XRayClient $xrayClient)
+    {
+        $this->xrayClient = $xrayClient;
+    }
+
+    public function fetch(): array
+    {
+        $samplingRules = [];
+    
+        // See: https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-xray-2016-04-12.html#getsamplingrules
+        foreach ($this->xrayClient->getPaginator("getSamplingRules") as $samplingRule) {
+            $samplingRules[] = $samplingRule["SamplingRule"];
+        }
+
+        return $samplingRules;
+    }
+}
+

--- a/src/SamplingRule/CachedSamplingRule.php
+++ b/src/SamplingRule/CachedSamplingRule.php
@@ -1,0 +1,42 @@
+<?php
+namespace Pkerrigan\Xray\SamplingRule;
+
+use Psr\SimpleCache\CacheInterface;
+
+class CachedSamplingRule implements SamplingRule
+{
+
+    public const CACHE_KEY = "Pkerrigan\Xray\SamplingRule";
+
+    /** @var SamplingRule */
+    private $samplingRule;
+
+    /** @var CacheInterface */
+    private $cache;
+
+    /** @var int */
+    private $cacheTtlSeconds;
+
+    public function __construct(
+        SamplingRule $samplingRule,
+        CacheInterface $cache,
+        int $cacheTtlSeconds = 3600)
+    {
+        $this->samplingRule = $samplingRule;
+        $this->cache = $cache;
+        $this->cacheTtlSeconds = $cacheTtlSeconds;
+    }
+
+    public function fetch(): array
+    {
+        if ($this->cache->has(self::CACHE_KEY)) {
+            return $this->cache->get(self::CACHE_KEY);
+        }
+
+        $samplingRules = $this->samplingRule->fetch();
+        $this->cache->set(self::CACHE_KEY, $samplingRules, $this->cacheTtlSeconds);
+
+        return $samplingRules;
+    }
+}
+

--- a/src/SamplingRule/SamplingRule.php
+++ b/src/SamplingRule/SamplingRule.php
@@ -1,0 +1,9 @@
+<?php
+namespace Pkerrigan\Xray\SamplingRule;
+
+interface SamplingRule
+{
+
+    public function fetch(): array;
+}
+

--- a/src/TraceManager.php
+++ b/src/TraceManager.php
@@ -1,0 +1,41 @@
+<?php
+namespace Pkerrigan\Xray;
+
+use Pkerrigan\Xray\SamplingRule\SamplingRule;
+use Pkerrigan\Xray\Submission\SegmentSubmitter;
+use Psr\Http\Message\ServerRequestInterface;
+
+class TraceManager
+{
+
+    /** @var SamplingRule */
+    private $samplingRule;
+
+    /** @var RequestMatcher */
+    private $requestMatcher;
+
+    /** @var SegmentSubmitter */
+    private $segmentSubmitter;
+
+    public function __construct(
+        SamplingRule $samplingRule,
+        RequestMatcher $requestMatcher,
+        SegmentSubmitter $segmentSubmitter)
+    {
+        $this->samplingRule = $samplingRule;
+        $this->requestMatcher = $requestMatcher;
+        $this->segmentSubmitter = $segmentSubmitter;
+    }
+
+    public function submit(
+        ServerRequestInterface $request,
+        Trace $trace): void
+    {
+        $samplingRules = $this->samplingRule->fetch();
+        $samplingRule = $this->requestMatcher->matches($request, $samplingRules);
+        $trace->setSampled($samplingRule !== null && (random_int(0, 99) < $samplingRule["FixedRate"] * 100));
+        
+        $trace->submit($this->segmentSubmitter);
+    }
+}
+


### PR DESCRIPTION
Thanks for the great effort! We're using this at the office since we're investing a lot in AWS, a shame that they don't support an official SDK.

The point with this PR is to [implement sampling rules from the AWS console](https://docs.aws.amazon.com/xray/latest/devguide/xray-api-sampling.html) in order to advance this SDK one step further. The PR at this stage is not complete at all and it's just a quick first draft. I haven't really read the link I provided in very much detail. Right now, I want your acknowledgment that you think this is a good idea and that you would consider merging this. Also, I want your opinion on the general API and if you think it fits with the current API and your coding style. Any class or variable names are a first draft, in general I'm adaptable!

So the core of the new functionality is the `SamplingRule` interface which defines how to fetch the sampling rules, with a default implementation of fetching them using the AWS SDK. The point is to make as few assumptions as possible and therefore things such as the `XrayClient` are injected by whoever consumes the library using whatever preferred method they have. The `CacheSamplingRule` is there in order to provide a way to wrap any implementation with caching, you'd probably want that in the long run. The `TraceManager` currently provides an abstraction layer on top of submitting traces in order to customize each trace with information from the sampling rules. Not all functionality from sampling rules are implemented, just the ones that is dependent on the current request.

We could make any dependency a `dev` dependency, explaining to library consumers that they can require certain packages in order to unlock more features.

As soon as we start a dialog I'd be happy to make any changes and add tests for everything that has been added. Also, I'll double check the provided link that it matches the implementation that has been written.

