### PR TITLE
fix: default subsegments to an empty array

### DIFF
--- a/src/Submission/DaemonSegmentSubmitter.php
+++ b/src/Submission/DaemonSegmentSubmitter.php
@@ -88,7 +88,7 @@ class DaemonSegmentSubmitter implements SegmentSubmitter
     {
         $rawSegment = $segment->jsonSerialize();
         /** @var Segment[] $subsegments */
-        $subsegments = $rawSegment['subsegments'];
+        $subsegments = $rawSegment['subsegments'] ?? [];
         unset($rawSegment['subsegments']);
         $this->submitOpenSegment($rawSegment);
 


### PR DESCRIPTION
`$segment->jsonSerialize()` returns subsegments as `null` if it's empty.