### PR TITLE
fix: use `traced` only for http subsegments

### DIFF
--- a/src/HttpSegment.php
+++ b/src/HttpSegment.php
@@ -22,4 +22,15 @@ class HttpSegment extends RemoteSegment
 
         return array_filter($data);
     }
+
+    /**
+     * @param bool $traced
+     * @return static
+     */
+    public function setTraced(bool $traced)
+    {
+        $this->traced = $traced;
+
+        return $this;
+    }
 }

--- a/src/HttpTrait.php
+++ b/src/HttpTrait.php
@@ -29,6 +29,10 @@ trait HttpTrait
      * @var int
      */
     protected $responseCode;
+    /**
+     * @var bool
+     */
+    protected $traced;
 
     /**
      * @param string $url
@@ -73,7 +77,8 @@ trait HttpTrait
                 'url' => $this->url,
                 'method' => $this->method,
                 'client_ip' => $this->clientIpAddress,
-                'user_agent' => $this->userAgent
+                'user_agent' => $this->userAgent,
+                'traced' => $this->traced
             ]),
             'response' => array_filter([
                 'status' => $this->responseCode

--- a/src/RemoteSegment.php
+++ b/src/RemoteSegment.php
@@ -15,6 +15,8 @@ class RemoteSegment extends Segment
     protected $traced = false;
 
     /**
+     * @deprecated Please use HttpSegment.setTraced
+     *
      * @param bool $traced
      * @return static
      */

--- a/tests/HttpSegmentTest.php
+++ b/tests/HttpSegmentTest.php
@@ -25,4 +25,15 @@ class HttpSegmentTest extends TestCase
         $this->assertEquals('GET', $serialised['http']['request']['method']);
         $this->assertEquals(200, $serialised['http']['response']['status']);
     }
+
+    public function testTracedSegmentSerialisesCorrectly()
+    {
+        $segment = new HttpSegment();
+        $segment->setTraced(true);
+
+        $serialised = $segment->jsonSerialize();
+
+        $this->assertEquals($segment->getId(), $serialised['id']);
+        $this->assertTrue($serialised['http']['request']['traced']);
+    }
 }


### PR DESCRIPTION
Now traced parameter is incorrectly used. Move it to the right place.

aws documentation: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-http