### PR TITLE
feat: allow setup aws.account_id for segments & subsegments

### DIFF
--- a/src/Segment.php
+++ b/src/Segment.php
@@ -58,6 +58,10 @@ class Segment implements JsonSerializable
      */
     protected $independent = false;
     /**
+     * @var int|null
+     */
+    protected $awsAccountId = null;
+    /**
      * @var string[]
      */
     private $annotations;
@@ -233,6 +237,17 @@ class Segment implements JsonSerializable
     }
 
     /**
+     * @param int $awsAccountId
+     * @return $this
+     */
+    public function setAwsAccountId(int $awsAccountId)
+    {
+        $this->awsAccountId = $awsAccountId;
+
+        return $this;
+    }
+
+    /**
      * @param string $key
      * @param string $value
      * @return static
@@ -287,7 +302,15 @@ class Segment implements JsonSerializable
             'fault' => $this->fault,
             'error' => $this->error,
             'annotations' => empty($this->annotations) ? null : $this->annotations,
-            'metadata' => empty($this->metadata) ? null : $this->metadata
+            'metadata' => empty($this->metadata) ? null : $this->metadata,
+            'aws' => $this->serialiseAwsData(),
+        ]);
+    }
+
+    protected function serialiseAwsData(): array
+    {
+        return array_filter([
+            'account_id' => $this->awsAccountId,
         ]);
     }
 }

--- a/tests/HttpSegmentTest.php
+++ b/tests/HttpSegmentTest.php
@@ -16,7 +16,8 @@ class HttpSegmentTest extends TestCase
         $segment = new HttpSegment();
         $segment->setUrl('http://example.com/')
             ->setMethod('GET')
-            ->setResponseCode(200);
+            ->setResponseCode(200)
+            ->setAwsAccountId(123);
 
         $serialised = $segment->jsonSerialize();
 
@@ -24,5 +25,6 @@ class HttpSegmentTest extends TestCase
         $this->assertEquals('http://example.com/', $serialised['http']['request']['url']);
         $this->assertEquals('GET', $serialised['http']['request']['method']);
         $this->assertEquals(200, $serialised['http']['response']['status']);
+        $this->assertEquals(123, $serialised['aws']['account_id']);
     }
 }

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -30,6 +30,7 @@ class TraceTest extends TestCase
             ->setClientIpAddress('127.0.0.1')
             ->setUserAgent('TestAgent')
             ->setResponseCode(200)
+            ->setAwsAccountId(123)
             ->begin()
             ->end();
 
@@ -44,6 +45,7 @@ class TraceTest extends TestCase
         $this->assertEquals('TestAgent', $serialised['http']['request']['user_agent']);
         $this->assertEquals(200, $serialised['http']['response']['status']);
         $this->assertEquals($trace->getTraceId(), $serialised['trace_id']);
+        $this->assertEquals(123, $serialised['aws']['account_id']);
     }
 
     public function testGeneratesCorrectFormatTraceId()


### PR DESCRIPTION
Segments:
> account_id – If your application sends segments to a different AWS account, record the ID of the account running your application.

Subsegments:
> account_id – If your application accesses resources in a different account, or sends segments to a different account, record the ID of the account that owns the AWS resource that your application accessed.

AWS Documentation: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html